### PR TITLE
Support multi-class segmentation for REFUGE dataset

### DIFF
--- a/cfg.py
+++ b/cfg.py
@@ -44,6 +44,7 @@ def parse_args():
     parser.add_argument('-roi_size', type=int, default=96 , help='resolution of roi')
     parser.add_argument('-evl_chunk', type=int, default=None , help='evaluation chunk')
     parser.add_argument('-mid_dim', type=int, default=None , help='middle dim of adapter or the rank of lora matrix')
+    parser.add_argument('-multimask_output', type=bool, default=False , help='multi mask output for multi-class segmentation, set True for REFUGE dataset.')
     parser.add_argument(
     '-data_path',
     type=str,

--- a/function.py
+++ b/function.py
@@ -161,7 +161,15 @@ def train_sam(args, net: nn.Module, optimizer, train_loader,
                         labels=labels_torch,
                     )
                     
-            if args.net == 'sam' or args.net == 'mobile_sam':
+            if args.net == 'sam':
+                pred, _ = net.mask_decoder(
+                    image_embeddings=imge,
+                    image_pe=net.prompt_encoder.get_dense_pe(), 
+                    sparse_prompt_embeddings=se,
+                    dense_prompt_embeddings=de, 
+                    multimask_output=args.multimask_output,
+                )
+            elif args.net == 'mobile_sam':
                 pred, _ = net.mask_decoder(
                     image_embeddings=imge,
                     image_pe=net.prompt_encoder.get_dense_pe(), 
@@ -169,7 +177,6 @@ def train_sam(args, net: nn.Module, optimizer, train_loader,
                     dense_prompt_embeddings=de, 
                     multimask_output=False,
                 )
-
             elif args.net == "efficient_sam":
                 se = se.view(
                     se.shape[0],
@@ -310,7 +317,15 @@ def validation_sam(args, val_loader, epoch, net: nn.Module, clean_dir=True):
                             labels=labels_torch,
                         )
 
-                    if args.net == 'sam' or args.net == 'mobile_sam':
+                    if args.net == 'sam':
+                        pred, _ = net.mask_decoder(
+                            image_embeddings=imge,
+                            image_pe=net.prompt_encoder.get_dense_pe(), 
+                            sparse_prompt_embeddings=se,
+                            dense_prompt_embeddings=de, 
+                            multimask_output=args.multimask_output,
+                        )
+                    elif args.net == 'mobile_sam':
                         pred, _ = net.mask_decoder(
                             image_embeddings=imge,
                             image_pe=net.prompt_encoder.get_dense_pe(), 

--- a/models/sam/modeling/mask_decoder.py
+++ b/models/sam/modeling/mask_decoder.py
@@ -99,8 +99,8 @@ class MaskDecoder(nn.Module):
         )
 
         # Select the correct mask or masks for output
-        if multimask_output:
-            mask_slice = slice(1, None)
+        if multimask_output: # for REFUGE dataset
+            mask_slice = slice(0, 2)
         else:
             mask_slice = slice(0, 1)
         masks = masks[:, mask_slice, :, :]

--- a/train.py
+++ b/train.py
@@ -153,9 +153,13 @@ best_tol = 1e4
 
 for epoch in range(settings.EPOCH):
     if epoch and epoch < 5:
-        tol, (eiou, edice) = function.validation_sam(args, nice_test_loader, epoch, net, writer)
-        logger.info(f'Total score: {tol}, IOU: {eiou}, DICE: {edice} || @ epoch {epoch}.')
-        
+        if args.dataset != 'REFUGE':
+            tol, (eiou, edice) = function.validation_sam(args, nice_test_loader, epoch, net, writer)
+            logger.info(f'Total score: {tol}, IOU: {eiou}, DICE: {edice} || @ epoch {epoch}.')
+        else:
+            tol, (eiou_cup, eiou_disc, edice_cup, edice_disc) = function.validation_sam(args, nice_test_loader, epoch, net, writer)
+            logger.info(f'Total score: {tol}, IOU_CUP: {eiou_cup}, IOU_DISC: {eiou_disc}, DICE_CUP: {edice_cup}, DICE_DISC: {edice_disc} || @ epoch {epoch}.')
+
     net.train()
     time_start = time.time()
     loss = function.train_sam(args, net, optimizer, nice_train_loader, epoch, writer, vis = args.vis)
@@ -165,8 +169,12 @@ for epoch in range(settings.EPOCH):
 
     net.eval()
     if epoch and epoch % args.val_freq == 0 or epoch == settings.EPOCH-1:
-        tol, (eiou, edice) = function.validation_sam(args, nice_test_loader, epoch, net, writer)
-        logger.info(f'Total score: {tol}, IOU: {eiou}, DICE: {edice} || @ epoch {epoch}.')
+        if args.dataset != 'REFUGE':
+            tol, (eiou, edice) = function.validation_sam(args, nice_test_loader, epoch, net, writer)
+            logger.info(f'Total score: {tol}, IOU: {eiou}, DICE: {edice} || @ epoch {epoch}.')
+        else:
+            tol, (eiou_cup, eiou_disc, edice_cup, edice_disc) = function.validation_sam(args, nice_test_loader, epoch, net, writer)
+            logger.info(f'Total score: {tol}, IOU_CUP: {eiou_cup}, IOU_DISC: {eiou_disc}, DICE_CUP: {edice_cup}, DICE_DISC: {edice_disc} || @ epoch {epoch}.')
 
         if args.distributed != 'none':
             sd = net.module.state_dict()

--- a/utils.py
+++ b/utils.py
@@ -963,12 +963,11 @@ def vis_image(imgs, pred_masks, gt_masks, save_path, reverse = False, points = N
     if reverse == True:
         pred_masks = 1 - pred_masks
         gt_masks = 1 - gt_masks
-    if c == 2:
+    if c == 2: # for REFUGE multi mask output
         pred_disc, pred_cup = pred_masks[:,0,:,:].unsqueeze(1).expand(b,3,h,w), pred_masks[:,1,:,:].unsqueeze(1).expand(b,3,h,w)
         gt_disc, gt_cup = gt_masks[:,0,:,:].unsqueeze(1).expand(b,3,h,w), gt_masks[:,1,:,:].unsqueeze(1).expand(b,3,h,w)
         tup = (imgs[:row_num,:,:,:],pred_disc[:row_num,:,:,:], pred_cup[:row_num,:,:,:], gt_disc[:row_num,:,:,:], gt_cup[:row_num,:,:,:])
-        # compose = torch.cat((imgs[:row_num,:,:,:],pred_disc[:row_num,:,:,:], pred_cup[:row_num,:,:,:], gt_disc[:row_num,:,:,:], gt_cup[:row_num,:,:,:]),0)
-        compose = torch.cat((pred_disc[:row_num,:,:,:], pred_cup[:row_num,:,:,:], gt_disc[:row_num,:,:,:], gt_cup[:row_num,:,:,:]),0)
+        compose = torch.cat(tup, 0)
         vutils.save_image(compose, fp = save_path, nrow = row_num, padding = 10)
     else:
         imgs = torchvision.transforms.Resize((h,w))(imgs)

--- a/val.py
+++ b/val.py
@@ -113,12 +113,28 @@ if args.dataset == 'isic':
 elif args.dataset == 'decathlon':
     nice_train_loader, nice_test_loader, transform_train, transform_val, train_list, val_list =get_decath_loader(args)
 
+elif args.dataset == 'REFUGE':
+    '''REFUGE data'''
+    refuge_train_dataset = REFUGE(args, args.data_path, transform = transform_train, transform_msk= transform_train_seg, mode = 'Training')
+    refuge_test_dataset = REFUGE(args, args.data_path, transform = transform_test, transform_msk= transform_test_seg, mode = 'Test')
+
+    nice_train_loader = DataLoader(refuge_train_dataset, batch_size=args.b, shuffle=True, num_workers=8, pin_memory=True)
+    nice_test_loader = DataLoader(refuge_test_dataset, batch_size=args.b, shuffle=False, num_workers=8, pin_memory=True)
+    '''end'''
+
+
 '''begain valuation'''
 best_acc = 0.0
 best_tol = 1e4
 
 if args.mod == 'sam_adpt':
     net.eval()
-    tol, (eiou, edice) = function.validation_sam(args, nice_test_loader, start_epoch, net)
-    logger.info(f'Total score: {tol}, IOU: {eiou}, DICE: {edice} || @ epoch {start_epoch}.')
+    
+    if args.dataset != 'REFUGE':
+        tol, (eiou, edice) = function.validation_sam(args, nice_test_loader, start_epoch, net)
+        logger.info(f'Total score: {tol}, IOU: {eiou}, DICE: {edice} || @ epoch {start_epoch}.')
+    else:
+        tol, (eiou_cup, eiou_disc, edice_cup, edice_disc) = function.validation_sam(args, nice_test_loader, start_epoch, net)
+        logger.info(f'Total score: {tol}, IOU_CUP: {eiou_cup}, IOU_DISC: {eiou_disc}, DICE_CUP: {edice_cup}, DICE_DISC: {edice_disc} || @ epoch {start_epoch}.')
+
     


### PR DESCRIPTION
This is for supporting two-class segmentation for REFUGE dataset. But in theory, without modifying the SAM pretrained checkpoint, a maximum of 4 classes can be supported by enabling multimask_output to output 4 masks (instead of 3 originally) in the MaskDecoder class.

Then in Dataset class, we need to stack the mask labels to form multiple masks as well.