### PR TITLE
Fix pickle error on Windows

### DIFF
--- a/dataset/__init__.py
+++ b/dataset/__init__.py
@@ -20,11 +20,15 @@ from .toothfairy import ToothFairy
 from .wbc import WBC
 
 
+def mul255(x):
+    return x * 255
+
+
 def get_dataloader(args):
     transform_train = transforms.Compose([
         transforms.Resize((args.image_size,args.image_size)),
         transforms.ToTensor(),
-        transforms.Lambda(lambda x: x * 255)
+        transforms.Lambda(mul255)
     ])
 
     transform_train_seg = transforms.Compose([
@@ -35,7 +39,7 @@ def get_dataloader(args):
     transform_test = transforms.Compose([
         transforms.Resize((args.image_size, args.image_size)),
         transforms.ToTensor(),
-        transforms.Lambda(lambda x: x * 255)
+        transforms.Lambda(mul255)
     ])
 
     transform_test_seg = transforms.Compose([


### PR DESCRIPTION
Here is a stack trace without this change:
```log
M:\Dev\CXR\.venv\Scripts\python.exe M:\Dev\CXR\Medical_SAM_Adapter\train.py -exp_name cxr_v5b -vis 1 -dataset cxr -mod sam_adpt -net sam -sam_ckpt Data/Models/sam_vit_b_01ec64.pth -encoder vit_b -data_path Data Namespace(seed=24, net='sam', baseline='unet', encoder='vit_b', seg_net='transunet', mod='sam_adpt', exp_name='cxr_v5b', type='map', vis=1, reverse=False, pretrain=False, val_freq=5, gpu=True, gpu_device=0, sim_gpu=0, epoch_ini=1, image_size=256, out_size=256, patch_size=2, dim=512, depth=1, heads=16, mlp_dim=1024, w=4, b=4, s=True, warm=1, lr=0.0001, uinch=1, imp_lr=0.0003, weights=0, base_weights=0, sim_weights=0, distributed='none', dataset='cxr', sam_ckpt='Data/Models/sam_vit_b_01ec64.pth', thd=False, chunk=None, num_sample=4, roi_size=96, evl_chunk=None, mid_dim=None, multimask_output=1, data_path='Data', path_helper={'prefix': 'logs\\cxr_v5b_2025_10_09_13_33_16', 'ckpt_path': 'logs\\cxr_v5b_2025_10_09_13_33_16\\Model', 'log_path': 'logs\\cxr_v5b_2025_10_09_13_33_16\\Log', 'sample_path': 'logs\\cxr_v5b_2025_10_09_13_33_16\\Samples'}) Traceback (most recent call last):
  File "M:\Dev\CXR\Medical_SAM_Adapter\train.py", line 150, in <module>
    main()
  File "M:\Dev\CXR\Medical_SAM_Adapter\train.py", line 104, in main
    tol, (eiou, edice) = function.validation_sam(args, nice_test_loader, epoch, net, writer)
  File "M:\Dev\CXR\Medical_SAM_Adapter\function.py", line 246, in validation_sam
    for ind, pack in enumerate(val_loader):
  File "M:\Dev\CXR\.venv\lib\site-packages\torch\utils\data\dataloader.py", line 439, in __iter__
    return self._get_iterator()
  File "M:\Dev\CXR\.venv\lib\site-packages\torch\utils\data\dataloader.py", line 387, in _get_iterator
    return _MultiProcessingDataLoaderIter(self)
  File "M:\Dev\CXR\.venv\lib\site-packages\torch\utils\data\dataloader.py", line 1040, in __init__
    w.start()
  File "C:\Program Files\Python39\lib\multiprocessing\process.py", line 121, in start
    self._popen = self._Popen(self)
  File "C:\Program Files\Python39\lib\multiprocessing\context.py", line 224, in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
  File "C:\Program Files\Python39\lib\multiprocessing\context.py", line 327, in _Popen
    return Popen(process_obj)
  File "C:\Program Files\Python39\lib\multiprocessing\popen_spawn_win32.py", line 93, in __init__
    reduction.dump(process_obj, to_child)
  File "C:\Program Files\Python39\lib\multiprocessing\reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
AttributeError: Can't pickle local object 'get_dataloader.<locals>.<lambda>'

Process finished with exit code 1
```